### PR TITLE
Use __DIR__ instead of getcwd()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config/*.php
 ladder.php
 migrations/
+cache/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config/*.php
 ladder.php
 migrations/
 cache/*
+

--- a/ladder.php
+++ b/ladder.php
@@ -3,10 +3,7 @@
 
 // This hack is to get the directory that Ladder is being used in,
 // based on default Composer settings.
-$application_path = implode(DIRECTORY_SEPARATOR, array(
-	getcwd(),
-	'ladder',
-));
+$application_path = __DIR__;
 
 // The system path we actually want to resolve the symlink.
 $system_path = __DIR__ . '/system';

--- a/system/core/commands/diff.php
+++ b/system/core/commands/diff.php
@@ -366,10 +366,17 @@ class FieldParser {
 
 		// Post-process the type.
 		if ((bool) preg_match('/([a-z]+)\(([\d,]+)\)/i', $type, $matches)) {
+			// types like type(length), i.e. varchar(25) or int(7)
 			$this->type = $matches[1];
 			$this->limit = $matches[2];
 			$this->enum_options = array();
+		} elseif ((bool) preg_match('/([a-z]+)/i', $type, $matches)) {
+			// types with no length in parentheses, like timestamp
+			$this->type = $matches[1];
+			$this->limit = 0;
+			$this->enum_options = array();
 		} elseif ((bool) preg_match('/(enum)\((.*?)\)/i', $type, $matches)) {
+			// enum sets
 			$this->type = $matches[1];
 			$this->limit = NULL;
 			$this->parse_enum_options($matches[2]);


### PR DESCRIPTION
getcwd() returns the directory in which the user last changed to,
irrelevant of where ladder.php is located. In other words, if you do
“cd /root/test/“ followed by “php /vendor/lib/ladder/ladder.php”,
getcwd() will return /root/test.

Using the **DIR** constant, on the other hand, always uses the
directory location of the file containing the **DIR** constant. In
other words, no matter how you launch ladder.php, it will always return
the correct directory.
